### PR TITLE
Update to the latest travis_setup.sh for Scala Native

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,6 @@ matrix:
   - sudo: required
     env: SCALA_NATIVE
     before_install:
-    - curl https://raw.githubusercontent.com/scala-native/scala-native/06e61984ca0f4/bin/travis_setup.sh | bash -
+    - curl https://raw.githubusercontent.com/scala-native/scala-native/master/scripts/travis_setup.sh | bash -
     script:
     - sbt "scalafmt::test" "test:scalafmt::test" "sbt:scalafmt::test" scalapbArgonautNative/test


### PR DESCRIPTION
[Recent PR](https://github.com/scala-native/scala-native/pull/1195) changed the location of the travis setup script within a Scala Native repo. This PR updates travis build to point to the new location.